### PR TITLE
feat: add standalone examples for different authentication flows

### DIFF
--- a/examples/button/README.md
+++ b/examples/button/README.md
@@ -1,0 +1,135 @@
+# Button Example - Login with OpenBunker
+
+A minimal standalone example showing the default "Login with OpenBunker" button flow with an optional email address input field. This example uses [nostr-tools](https://github.com/nbd-wtf/nostr-tools) v2.19.3 to decode the bunker URL and extract the user's npub.
+
+## What This Demonstrates
+
+- Simple popup-based authentication with OpenBunker
+- Optional email pre-fill for faster onboarding
+- Listening for authentication success via `postMessage`
+
+## Files
+
+```bash
+button/
+├── index.html   # Main HTML with the login button
+├── style.css    # Styles for the UI
+└── README.md    # This file
+```
+
+## How It Works
+
+### 1. User Clicks "Login with OpenBunker"
+
+The button opens a popup window pointing to the OpenBunker login page:
+
+```javascript
+const url = new URL(
+  'https://openbunker.opencollective.xyz/openbunker-login-popup'
+);
+
+if (email) {
+  url.searchParams.set('email', email);
+}
+
+window.open(url.toString(), 'openbunker-login', 'width=500,height=600');
+```
+
+### 2. User Authenticates in the Popup
+
+The user completes authentication in the OpenBunker popup (social login, email, etc.)
+
+### 3. Popup Sends Success Message
+
+When authentication succeeds, OpenBunker sends a `postMessage` to the parent window:
+
+```javascript
+// OpenBunker sends this:
+window.opener.postMessage(
+  {
+    type: 'openbunker-auth-success',
+    npub: 'npub1...',
+    // other data...
+  },
+  '*'
+);
+```
+
+### 4. Your App Receives the Message
+
+Listen for the message and update your UI:
+
+```javascript
+window.addEventListener('message', event => {
+  // Optional: verify origin
+  // if (event.origin !== 'https://openbunker.opencollective.xyz') return;
+
+  if (event.data && event.data.type === 'openbunker-auth-success') {
+    console.log('Authenticated!', event.data.npub);
+    // Update your app state
+  }
+});
+```
+
+## Configuration
+
+Edit the `CONFIG` object in `index.html`:
+
+```javascript
+const CONFIG = {
+  OPENBUNKER_POPUP_URL:
+    'https://openbunker.opencollective.xyz/openbunker-login-popup',
+};
+```
+
+## Running the Example
+
+### Option 1: Open directly
+
+Just open `index.html` in your browser.
+
+### Option 2: Use a local server
+
+```bash
+# From the examples/button directory
+npx serve .
+# or
+python -m http.server 8000
+```
+
+Then visit `http://localhost:8000` (or `http://localhost:3000` for serve).
+
+## Customization
+
+### Pre-fill Email
+
+Pass an email to speed up the signup process:
+
+```javascript
+url.searchParams.set('email', 'user@example.com');
+```
+
+### Custom Styling
+
+Edit `style.css` to match your app's design.
+
+### Redirect Instead of Popup
+
+For mobile or when popups are blocked, use redirect flow:
+
+```javascript
+// Redirect to OpenBunker with a return URL
+const url = new URL(
+  'https://openbunker.opencollective.xyz/openbunker-login-popup'
+);
+
+url.searchParams.set('redirectUrl', window.location.href);
+
+window.location.href = url.toString();
+```
+
+## Security Notes
+
+- Consider verifying `event.origin` in the message handler
+- The popup URL should always use HTTPS in production
+- Store authentication tokens securely (not in localStorage for sensitive apps)

--- a/examples/button/index.html
+++ b/examples/button/index.html
@@ -1,0 +1,212 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="style.css" />
+    <title>OpenBunker - Button Example</title>
+    <script type="module">
+      // Import nostr-tools at the top for better performance
+      import * as NostrTools from 'https://esm.sh/nostr-tools@2.19.3';
+      window.NostrTools = NostrTools;
+    </script>
+  </head>
+
+  <body>
+    <div class="card">
+      <!-- Login View -->
+      <div id="login-view">
+        <h1>Button Example</h1>
+
+        <label for="email">Email (optional)</label>
+
+        <input type="email" id="email" placeholder="you@example.com" />
+
+        <p class="hint">Pre-fill your email for faster signup</p>
+
+        <button class="btn btn-primary" id="login-btn">
+          Login with OpenBunker
+        </button>
+
+        <div class="status">Status: <span id="status">disconnected</span></div>
+      </div>
+
+      <!-- Success View -->
+      <div id="success-view" class="hidden">
+        <div class="success">
+          <div class="success-icon">
+            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M5 13l4 4L19 7"
+              />
+            </svg>
+          </div>
+
+          <h1>Authenticated!</h1>
+
+          <p class="npub" id="npub"></p>
+
+          <button class="btn btn-danger" id="logout-btn">Logout</button>
+        </div>
+      </div>
+    </div>
+
+    <script type="module">
+      // ============================================================
+      // CONFIGURATION - Set these values for your OpenBunker instance
+      // ============================================================
+      const CONFIG = {
+        OPENBUNKER_ORIGIN: 'https://openbunker.opencollective.xyz',
+        OPENBUNKER_POPUP_URL:
+          'https://openbunker.opencollective.xyz/openbunker-login-popup',
+      };
+
+      // ============================================================
+      // STATE
+      // ============================================================
+      let state = {
+        status: 'disconnected', // disconnected | connecting | connected
+        npub: null,
+        popup: null,
+      };
+
+      // ============================================================
+      // DOM ELEMENTS
+      // ============================================================
+      const loginView = document.getElementById('login-view'),
+        successView = document.getElementById('success-view'),
+        emailInput = document.getElementById('email'),
+        loginBtn = document.getElementById('login-btn'),
+        logoutBtn = document.getElementById('logout-btn'),
+        statusEl = document.getElementById('status'),
+        npubEl = document.getElementById('npub');
+
+      // ============================================================
+      // FUNCTIONS
+      // ============================================================
+      function updateUI() {
+        statusEl.textContent = state.status;
+
+        if (state.status === 'connected') {
+          loginView.classList.add('hidden');
+          successView.classList.remove('hidden');
+
+          npubEl.textContent = state.npub;
+        } else {
+          loginView.classList.remove('hidden');
+          successView.classList.add('hidden');
+        }
+
+        loginBtn.textContent =
+          state.status === 'connecting'
+            ? 'Connecting...'
+            : 'Login with OpenBunker';
+
+        loginBtn.disabled = state.status === 'connecting';
+      }
+
+      function openPopup() {
+        state.status = 'connecting';
+
+        updateUI();
+
+        const email = emailInput.value,
+          url = new URL(CONFIG.OPENBUNKER_POPUP_URL);
+
+        if (email) {
+          url.searchParams.set('email', email);
+        }
+
+        // Open popup
+        state.popup = window.open(
+          url.toString(),
+          'openbunker-login',
+          'width=500,height=600,scrollbars=yes,resizable=yes'
+        );
+
+        // Check if popup closed
+        const checkClosed = setInterval(() => {
+          if (state.popup && state.popup.closed) {
+            clearInterval(checkClosed);
+
+            state.popup = null;
+
+            if (state.status === 'connecting') {
+              state.status = 'disconnected';
+
+              updateUI();
+            }
+          }
+        }, 1000);
+      }
+
+      function handleAuthSuccess(event) {
+        // Verify origin matches your OpenBunker instance
+        if (event.origin !== CONFIG.OPENBUNKER_ORIGIN) return;
+
+        if (event.data && event.data.type === 'openbunker-auth-success') {
+          console.log('Auth success:', event.data);
+
+          // Close popup if still open
+          if (state.popup) {
+            state.popup.close();
+            state.popup = null;
+          }
+
+          // Extract npub from the bunker URL
+          if (event.data.connectionMode === 'bunker' && event.data.secretKey) {
+            try {
+              // Parse the bunker URL (format: bunker://<pubkey>?relay=...&secret=...)
+              const bunkerUrl = event.data.secretKey;
+              const match = bunkerUrl.match(/^bunker:\/\/([0-9a-f]{64})/);
+
+              if (match && match[1]) {
+                // Convert hex pubkey to npub using nostr-tools
+                state.npub = NostrTools.nip19.npubEncode(match[1]);
+                state.status = 'connected';
+              } else {
+                console.error('Invalid bunker URL format:', bunkerUrl);
+                state.status = 'disconnected';
+                return;
+              }
+            } catch (error) {
+              console.error('Failed to parse bunker URL:', error);
+              state.status = 'disconnected';
+              return;
+            }
+          } else if (event.data.npub) {
+            state.npub = event.data.npub;
+            state.status = 'connected';
+          } else {
+            console.error('No valid authentication data received');
+            state.status = 'disconnected';
+            return;
+          }
+
+          updateUI();
+        }
+      }
+
+      function logout() {
+        state.status = 'disconnected';
+        state.npub = null;
+
+        updateUI();
+      }
+
+      // ============================================================
+      // EVENT LISTENERS
+      // ============================================================
+      loginBtn.addEventListener('click', openPopup);
+      logoutBtn.addEventListener('click', logout);
+
+      window.addEventListener('message', handleAuthSuccess);
+
+      // Initial render
+      updateUI();
+    </script>
+  </body>
+</html>

--- a/examples/button/style.css
+++ b/examples/button/style.css
@@ -1,0 +1,125 @@
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f3f4f6;
+}
+
+.card {
+  background: white;
+  padding: 2rem;
+  border-radius: 12px;
+  box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1);
+  max-width: 400px;
+  width: 100%;
+}
+
+h1 {
+  font-size: 1.5rem;
+  text-align: center;
+  margin-bottom: 1.5rem;
+  color: #111;
+}
+
+label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #374151;
+  margin-bottom: 0.5rem;
+}
+
+input {
+  width: 100%;
+  padding: 0.625rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-size: 1rem;
+  margin-bottom: 1rem;
+}
+
+input:focus {
+  outline: none;
+  border-color: #10b981;
+  box-shadow: 0 0 0 2px rgba(16, 185, 129, 0.2);
+}
+
+.hint {
+  font-size: 0.75rem;
+  color: #6b7280;
+  margin-top: -0.75rem;
+  margin-bottom: 1rem;
+}
+
+.btn {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.btn-primary {
+  background: linear-gradient(to right, #059669, #10b981);
+  color: white;
+}
+
+.btn-primary:hover {
+  background: linear-gradient(to right, #047857, #059669);
+}
+
+.btn-danger {
+  background: #dc2626;
+  color: white;
+  margin-top: 1rem;
+}
+
+.btn-danger:hover {
+  background: #b91c1c;
+}
+
+.status {
+  text-align: center;
+  font-size: 0.875rem;
+  color: #6b7280;
+  margin-top: 1rem;
+}
+
+.success {
+  text-align: center;
+}
+
+.success-icon {
+  width: 4rem;
+  height: 4rem;
+  background: #d1fae5;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 1rem;
+}
+
+.success-icon svg {
+  width: 2rem;
+  height: 2rem;
+  color: #059669;
+}
+
+.npub {
+  font-size: 0.75rem;
+  color: #6b7280;
+  word-break: break-all;
+  margin-top: 0.5rem;
+}
+
+.hidden {
+  display: none;
+}

--- a/examples/queue/README.md
+++ b/examples/queue/README.md
@@ -1,0 +1,256 @@
+# Queue Example - 6-Digit Code Flow
+
+A minimal standalone example showing the "requests" flow where your app handles the 6-digit code input and submits events after successful authentication. **This is a fully working implementation** that uses the OpenBunker API and [nostr-tools](https://github.com/nbd-wtf/nostr-tools) v2.19.3 BunkerSigner.
+
+## What This Demonstrates
+
+- Email-based authentication with verification code
+- Custom UI for the 6-digit code input (your app controls the UX)
+- Complete bunker connection flow using nostr-tools
+- Event signing with BunkerSigner
+
+## Files
+
+```bash
+queue/
+├── index.html   # Main HTML with email/code/success screens
+├── style.css    # Styles for the UI
+└── README.md    # This file
+```
+
+## How It Works
+
+### Step 1: Request Verification Code
+
+User enters their email. Your app calls the OpenBunker API:
+
+```javascript
+const response = await fetch(
+  'https://openbunker.opencollective.xyz/api/openbunker-unauthenticated-token',
+  {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      email: 'user@example.com',
+      scope: 'community-requests', // Your community/app identifier
+    }),
+  }
+);
+
+const data = await response.json();
+// data.bunkerConnectionToken - store this for step 3
+// data.success - true if code was sent
+```
+
+### Step 2: User Enters 6-Digit Code
+
+Display 6 input boxes. The example includes:
+
+- Auto-advance to next input on entry
+- Backspace navigation
+- Paste support for full code
+
+```html
+<div class="code-container">
+  <input type="text" class="code-input" maxlength="1" inputmode="numeric" />
+  <!-- ... 5 more inputs -->
+</div>
+```
+
+### Step 3: Verify Code and Connect
+
+When the user enters the 6-digit code, your app connects using BunkerSigner:
+
+```javascript
+import * as NostrTools from 'https://esm.sh/nostr-tools@2.19.3';
+import {
+  BunkerSigner,
+  parseBunkerInput,
+} from 'https://esm.sh/nostr-tools@2.19.3/nip46';
+
+// Add the secret code to the bunker URL
+const url = new URL(bunkerToken);
+url.searchParams.set('secret', code);
+
+// Generate a local private key for this session
+const localPrivKey = NostrTools.generateSecretKey();
+const bunkerPointer = await parseBunkerInput(url.toString());
+
+// Create and connect the BunkerSigner
+const signer = await BunkerSigner.fromBunker(localPrivKey, bunkerPointer, {
+  onauth: async authUrl => {
+    // If code is wrong, popup will open for authentication
+    // Handle popup auth flow here
+    await handlePopupAuth(authUrl);
+    throw new Error('POPUP_AUTH_COMPLETE');
+  },
+});
+
+await signer.connect();
+const pubkey = await signer.getPublicKey();
+```
+
+**Note:** If the user enters an incorrect code, the `onauth` callback is triggered, which opens a popup for authentication. This provides a fallback authentication method.
+
+### Step 4: Submit Events
+
+Once authenticated, sign and submit Nostr events using the signer:
+
+```javascript
+const event = {
+  kind: 1,
+  content: 'Hello from OpenBunker Queue Example!',
+  tags: [],
+  created_at: Math.floor(Date.now() / 1000),
+};
+
+// The bunker signs this event with the user's key
+const signedEvent = await signer.signEvent(event);
+
+// Now you can publish signedEvent to Nostr relays
+```
+
+## Configuration
+
+The example uses the production OpenBunker instance:
+
+```javascript
+const CONFIG = {
+  OPENBUNKER_ORIGIN: 'https://openbunker.opencollective.xyz',
+  OPENBUNKER_API_URL:
+    'https://openbunker.opencollective.xyz/api/openbunker-unauthenticated-token',
+};
+```
+
+**Note:** The example imports `nostr-tools@2.19.3` from esm.sh CDN using ESM imports at the top of the script. Both the main module and the nip46 sub-module are imported to access core utilities and `BunkerSigner`/`parseBunkerInput`.
+
+## Running the Example
+
+### Option 1: Open directly
+
+Just open `index.html` in your browser.
+
+**This example works directly in the browser!** The nostr-tools library is loaded from CDN, and the OpenBunker API has proper CORS headers.
+
+### Option 2: Use a local server
+
+```bash
+# From the examples/queue directory
+npx serve .
+# or
+python -m http.server 8000
+```
+
+## API Reference
+
+### POST /api/openbunker-unauthenticated-token
+
+Request a verification code for an email.
+
+**Request:**
+
+```json
+{
+  "email": "user@example.com",
+  "scope": "community-requests"
+}
+```
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "message": "Verification code sent",
+  "bunkerConnectionToken": "bunker://...",
+  "tokenId": "uuid"
+}
+```
+
+### Bunker Connection
+
+After receiving the `bunkerConnectionToken`, the example uses the NIP-46 BunkerSigner implementation from nostr-tools:
+
+1. **Parse the bunker URI** - The token is a `bunker://` URL containing the remote signer's pubkey
+2. **Add the secret** - The 6-digit code is added as the `secret` query parameter
+3. **Create BunkerSigner** - Connects to the bunker using a local ephemeral key
+4. **Handle auth popup** - If needed, the bunker may request OAuth authentication via popup
+5. **Sign events** - Once connected, use `signer.signEvent()` to sign Nostr events
+
+This implementation is based on the production code from [openletter](https://github.com/rabble/openletter), which successfully uses OpenBunker for email authentication.
+
+See [NIP-46](https://github.com/nostr-protocol/nips/blob/master/46.md) for the full Nostr bunker protocol specification.
+
+## Event Queue Pattern
+
+The "queue" pattern allows you to:
+
+1. Let users compose content before authenticating
+2. Queue the event for submission
+3. Process the queue after authentication succeeds
+
+```javascript
+// Before auth - queue the event
+const pendingEvents = [];
+
+pendingEvents.push({
+  kind: 1,
+  content: 'User wrote this before logging in',
+  tags: [],
+});
+
+// After auth - process queue
+for (const event of pendingEvents) {
+  const signed = await bunkerSigner.signEvent(event);
+
+  await publishToRelays(signed);
+}
+
+pendingEvents.length = 0;
+```
+
+## Customization
+
+### Custom Scope
+
+The `scope` parameter identifies your community or app:
+
+```javascript
+{
+  body: JSON.stringify({
+    email,
+    scope: 'my-community-name',
+  });
+}
+```
+
+### Custom Code Input Style
+
+Edit `style.css` to change the appearance of the code inputs:
+
+```css
+.code-input {
+  width: 3rem;
+  height: 3.5rem;
+  font-size: 1.5rem;
+  /* your styles */
+}
+```
+
+### Error Handling
+
+The example shows errors in a red box. Customize the error display:
+
+```javascript
+function showError(message) {
+  errorEl.textContent = message;
+  errorEl.classList.remove('hidden');
+}
+```
+
+## Security Notes
+
+- The 6-digit code expires after a short time
+- Codes are single-use
+- The `bunkerConnectionToken` should be kept in memory, not persisted
+- Always use HTTPS in production

--- a/examples/queue/index.html
+++ b/examples/queue/index.html
@@ -1,0 +1,536 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="style.css" />
+    <title>OpenBunker - Queue Example</title>
+  </head>
+
+  <body>
+    <div class="card">
+      <h1>Queue Example</h1>
+
+      <p class="subtitle">6-digit code flow with event submission</p>
+
+      <!-- Step 1: Email Input -->
+      <div id="email-step">
+        <label for="email">Email Address</label>
+
+        <input type="email" id="email" placeholder="you@example.com" required />
+
+        <label for="scope">Scope</label>
+
+        <input
+          type="text"
+          id="scope"
+          value="community-requests"
+          placeholder="community-requests"
+        />
+
+        <button class="btn btn-primary" id="send-code-btn">
+          Send Verification Code
+        </button>
+      </div>
+
+      <!-- Step 2: Code Input -->
+      <div id="code-step" class="hidden">
+        <p class="code-hint">
+          Enter the 6-digit code sent to
+          <strong id="email-display"></strong>
+        </p>
+
+        <div class="code-container">
+          <input
+            type="text"
+            class="code-input"
+            maxlength="1"
+            inputmode="numeric"
+            data-index="0"
+          />
+          <input
+            type="text"
+            class="code-input"
+            maxlength="1"
+            inputmode="numeric"
+            data-index="1"
+          />
+          <input
+            type="text"
+            class="code-input"
+            maxlength="1"
+            inputmode="numeric"
+            data-index="2"
+          />
+          <input
+            type="text"
+            class="code-input"
+            maxlength="1"
+            inputmode="numeric"
+            data-index="3"
+          />
+          <input
+            type="text"
+            class="code-input"
+            maxlength="1"
+            inputmode="numeric"
+            data-index="4"
+          />
+          <input
+            type="text"
+            class="code-input"
+            maxlength="1"
+            inputmode="numeric"
+            data-index="5"
+          />
+        </div>
+
+        <button class="btn btn-primary" id="verify-btn" disabled>
+          Verify & Submit Event
+        </button>
+
+        <button class="btn btn-link" id="back-btn">← Back to email</button>
+      </div>
+
+      <!-- Step 3: Success -->
+      <div id="success-step" class="hidden">
+        <div class="success">
+          <div class="success-icon">
+            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M5 13l4 4L19 7"
+              />
+            </svg>
+          </div>
+
+          <h1>Authenticated!</h1>
+
+          <p class="npub" id="npub"></p>
+
+          <div class="event-box">
+            <p>Event Submitted:</p>
+            <code id="event-id"></code>
+          </div>
+
+          <button class="btn btn-danger" id="logout-btn">Logout</button>
+        </div>
+      </div>
+
+      <!-- Error Display -->
+      <div id="error" class="error hidden"></div>
+
+      <!-- Status -->
+      <div class="status">Status: <span id="status">disconnected</span></div>
+    </div>
+
+    <script type="module">
+      import * as NostrTools from 'https://esm.sh/nostr-tools@2.19.3';
+      import {
+        BunkerSigner,
+        parseBunkerInput,
+      } from 'https://esm.sh/nostr-tools@2.19.3/nip46';
+
+      // ============================================================
+      // CONFIGURATION - Set these values for your OpenBunker instance
+      // ============================================================
+      const CONFIG = {
+        OPENBUNKER_ORIGIN: 'https://openbunker.opencollective.xyz',
+        OPENBUNKER_API_URL:
+          'https://openbunker.opencollective.xyz/api/openbunker-unauthenticated-token',
+      };
+
+      // ============================================================
+      // STATE
+      // ============================================================
+      let state = {
+        step: 'email', // email | code | success
+        status: 'disconnected',
+        email: '',
+        bunkerToken: null,
+        npub: null,
+        eventId: null,
+        loading: false,
+        error: null,
+      };
+
+      // ============================================================
+      // DOM ELEMENTS
+      // ============================================================
+      const emailStep = document.getElementById('email-step'),
+        codeStep = document.getElementById('code-step'),
+        successStep = document.getElementById('success-step'),
+        emailInput = document.getElementById('email'),
+        scopeInput = document.getElementById('scope'),
+        emailDisplay = document.getElementById('email-display'),
+        codeInputs = document.querySelectorAll('.code-input'),
+        sendCodeBtn = document.getElementById('send-code-btn'),
+        verifyBtn = document.getElementById('verify-btn'),
+        backBtn = document.getElementById('back-btn'),
+        logoutBtn = document.getElementById('logout-btn'),
+        statusEl = document.getElementById('status'),
+        npubEl = document.getElementById('npub'),
+        eventIdEl = document.getElementById('event-id'),
+        errorEl = document.getElementById('error');
+
+      // ============================================================
+      // FUNCTIONS
+      // ============================================================
+      function showError(message) {
+        state.error = message;
+        errorEl.textContent = message;
+        errorEl.classList.remove('hidden');
+      }
+
+      function clearError() {
+        state.error = null;
+        errorEl.classList.add('hidden');
+      }
+
+      function updateUI() {
+        statusEl.textContent = state.status;
+
+        clearError();
+
+        // Show/hide steps
+        emailStep.classList.toggle('hidden', state.step !== 'email');
+        codeStep.classList.toggle('hidden', state.step !== 'code');
+        successStep.classList.toggle('hidden', state.step !== 'success');
+
+        // Update button states
+        sendCodeBtn.textContent = state.loading
+          ? 'Sending...'
+          : 'Send Verification Code';
+
+        sendCodeBtn.disabled = state.loading;
+
+        verifyBtn.textContent = state.loading
+          ? 'Verifying...'
+          : 'Verify & Submit Event';
+
+        if (state.step === 'code') {
+          emailDisplay.textContent = state.email;
+        }
+
+        if (state.step === 'success') {
+          npubEl.textContent = state.npub;
+          eventIdEl.textContent = state.eventId;
+        }
+      }
+
+      function getCode() {
+        return Array.from(codeInputs)
+          .map(input => input.value)
+          .join('');
+      }
+
+      function updateVerifyButton() {
+        const code = getCode();
+
+        verifyBtn.disabled = code.length !== 6 || state.loading;
+      }
+
+      async function requestCode() {
+        const email = emailInput.value.trim(),
+          scope = scopeInput.value.trim();
+
+        if (!email) {
+          showError('Please enter your email address');
+          return;
+        }
+
+        state.loading = true;
+        state.email = email;
+
+        updateUI();
+
+        try {
+          const response = await fetch(CONFIG.OPENBUNKER_API_URL, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email, scope }),
+          });
+
+          const data = await response.json();
+
+          if (data.success && data.bunkerConnectionToken) {
+            state.bunkerToken = data.bunkerConnectionToken;
+            state.step = 'code';
+            state.loading = false;
+
+            updateUI();
+
+            // Focus first code input
+            codeInputs[0].focus();
+          } else {
+            throw new Error(data.error || 'Failed to send verification code');
+          }
+        } catch (err) {
+          state.loading = false;
+
+          updateUI();
+
+          showError(err.message);
+        }
+      }
+
+      async function verifyCode() {
+        const code = getCode();
+
+        if (code.length !== 6) {
+          showError('Please enter all 6 digits');
+          return;
+        }
+
+        state.loading = true;
+        state.status = 'connecting';
+
+        updateUI();
+
+        try {
+          console.log('Attempting to verify code...');
+
+          // Add the 6-digit code as the secret parameter
+          const url = new URL(state.bunkerToken);
+          url.searchParams.set('secret', code);
+
+          const localPrivKey = NostrTools.generateSecretKey(),
+            bunkerPointer = await parseBunkerInput(url.toString());
+
+          if (!bunkerPointer) {
+            throw new Error('Invalid bunker URL format');
+          }
+
+          // Create BunkerSigner with fallback popup auth if code is wrong
+          const signer = await BunkerSigner.fromBunker(
+            localPrivKey,
+            bunkerPointer,
+            {
+              onauth: async authUrl => {
+                console.log(
+                  'Code was incorrect, opening popup authentication...'
+                );
+                // Wrong code - fallback to popup authentication
+                await handlePopupAuth(authUrl);
+                throw new Error('POPUP_AUTH_COMPLETE');
+              },
+            }
+          );
+
+          try {
+            await signer.connect();
+            await completeAuthWithSigner(signer);
+          } catch (connectErr) {
+            if (connectErr.message === 'POPUP_AUTH_COMPLETE') return;
+
+            throw connectErr;
+          }
+        } catch (err) {
+          state.loading = false;
+          state.status = 'disconnected';
+
+          updateUI();
+
+          showError(err.message);
+        }
+      }
+
+      async function handlePopupAuth(authUrl) {
+        return new Promise((resolve, reject) => {
+          const authPopup = window.open(
+            authUrl,
+            'bunkerAuth',
+            'width=500,height=600,scrollbars=yes,resizable=yes'
+          );
+
+          const messageHandler = async event => {
+            if (event.origin !== CONFIG.OPENBUNKER_ORIGIN) return;
+
+            if (event.data?.type === 'openbunker-auth-success') {
+              console.log('Auth success:', event.data);
+              cleanup();
+              authPopup?.close();
+
+              if (event.data.secretKey) {
+                try {
+                  const localPrivKey = NostrTools.generateSecretKey(),
+                    bunkerPointer = await parseBunkerInput(
+                      event.data.secretKey
+                    ),
+                    signer = await BunkerSigner.fromBunker(
+                      localPrivKey,
+                      bunkerPointer
+                    );
+
+                  await signer.connect();
+
+                  await completeAuthWithSigner(signer);
+
+                  resolve();
+                } catch (err) {
+                  showError(err.message || 'Failed to connect');
+
+                  state.status = 'disconnected';
+                  state.loading = false;
+
+                  updateUI();
+
+                  reject(err);
+                }
+              } else {
+                console.error('No bunker URL in auth response');
+                showError('No bunker URL in auth response');
+
+                state.status = 'disconnected';
+                state.loading = false;
+
+                updateUI();
+
+                reject(new Error('No bunker URL'));
+              }
+            }
+          };
+
+          window.addEventListener('message', messageHandler);
+
+          const checkInterval = setInterval(() => {
+            if (authPopup?.closed) {
+              cleanup();
+
+              showError('Authentication cancelled');
+
+              state.status = 'disconnected';
+              state.loading = false;
+
+              updateUI();
+
+              reject(new Error('Popup closed'));
+            }
+          }, 500);
+
+          const timeoutId = setTimeout(() => {
+            cleanup();
+            if (authPopup && !authPopup.closed) {
+              authPopup.close();
+            }
+            showError('Authentication timeout');
+            state.status = 'disconnected';
+            state.loading = false;
+            updateUI();
+            reject(new Error('Timeout'));
+          }, 120000);
+
+          const cleanup = () => {
+            window.removeEventListener('message', messageHandler);
+            clearInterval(checkInterval);
+            clearTimeout(timeoutId);
+          };
+        });
+      }
+
+      async function completeAuthWithSigner(signer) {
+        const pubkey = await signer.getPublicKey();
+        console.log('Got public key:', pubkey);
+
+        // Create and sign a test event
+        const event = {
+          kind: 1,
+          created_at: Math.floor(Date.now() / 1000),
+          tags: [],
+          content: 'Hello from OpenBunker Queue Example!',
+        };
+
+        const signedEvent = await signer.signEvent(event);
+
+        state.status = 'connected';
+        state.npub = NostrTools.nip19.npubEncode(pubkey);
+        state.eventId = signedEvent.id;
+        state.step = 'success';
+        state.loading = false;
+
+        updateUI();
+      }
+
+      function goBack() {
+        state.step = 'email';
+
+        codeInputs.forEach(input => (input.value = ''));
+
+        updateUI();
+      }
+
+      function logout() {
+        state = {
+          step: 'email',
+          status: 'disconnected',
+          email: '',
+          bunkerToken: null,
+          npub: null,
+          eventId: null,
+          loading: false,
+          error: null,
+        };
+
+        codeInputs.forEach(input => (input.value = ''));
+        emailInput.value = '';
+
+        updateUI();
+      }
+
+      // ============================================================
+      // EVENT LISTENERS
+      // ============================================================
+      sendCodeBtn.addEventListener('click', requestCode);
+      verifyBtn.addEventListener('click', verifyCode);
+      backBtn.addEventListener('click', goBack);
+      logoutBtn.addEventListener('click', logout);
+
+      emailInput.addEventListener('keypress', e => {
+        if (e.key === 'Enter') requestCode();
+      });
+
+      // Code input handling
+      codeInputs.forEach((input, index) => {
+        input.addEventListener('input', e => {
+          const value = e.target.value;
+          if (!/^\d*$/.test(value)) {
+            e.target.value = '';
+            return;
+          }
+          if (value && index < 5) codeInputs[index + 1].focus();
+          updateVerifyButton();
+        });
+
+        input.addEventListener('keydown', e => {
+          if (e.key === 'Backspace' && !input.value && index > 0) {
+            codeInputs[index - 1].focus();
+          }
+
+          if (e.key === 'Enter' && getCode().length === 6) verifyCode();
+        });
+
+        input.addEventListener('paste', e => {
+          e.preventDefault();
+
+          const pastedData = e.clipboardData
+            .getData('text')
+            .replace(/\D/g, '')
+            .slice(0, 6);
+
+          pastedData.split('').forEach((digit, i) => {
+            if (codeInputs[i]) codeInputs[i].value = digit;
+          });
+
+          updateVerifyButton();
+
+          if (pastedData.length === 6) codeInputs[5].focus();
+        });
+      });
+
+      // Initialize
+      updateUI();
+    </script>
+  </body>
+</html>

--- a/examples/queue/style.css
+++ b/examples/queue/style.css
@@ -1,0 +1,201 @@
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f3f4f6;
+}
+
+.card {
+  background: white;
+  padding: 2rem;
+  border-radius: 12px;
+  box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1);
+  max-width: 400px;
+  width: 100%;
+}
+
+h1 {
+  font-size: 1.5rem;
+  text-align: center;
+  color: #111;
+}
+
+.subtitle {
+  font-size: 0.875rem;
+  color: #6b7280;
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #374151;
+  margin-bottom: 0.5rem;
+}
+
+input {
+  width: 100%;
+  padding: 0.625rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-size: 1rem;
+  margin-bottom: 1rem;
+}
+
+input:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
+}
+
+.btn {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background: #4f46e5;
+  color: white;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: #4338ca;
+}
+
+.btn-link {
+  background: none;
+  color: #6b7280;
+  font-size: 0.875rem;
+  margin-top: 0.5rem;
+}
+
+.btn-link:hover {
+  color: #374151;
+}
+
+.btn-danger {
+  background: #dc2626;
+  color: white;
+  margin-top: 1rem;
+}
+
+.btn-danger:hover {
+  background: #b91c1c;
+}
+
+/* Code input */
+.code-container {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  margin: 1.5rem 0;
+}
+
+.code-input {
+  width: 3rem;
+  height: 3.5rem;
+  text-align: center;
+  font-size: 1.5rem;
+  font-family: monospace;
+  padding: 0;
+}
+
+.code-hint {
+  text-align: center;
+  color: #6b7280;
+  margin-bottom: 1rem;
+}
+
+.code-hint strong {
+  color: #111;
+}
+
+/* Success */
+.success {
+  text-align: center;
+}
+
+.success-icon {
+  width: 4rem;
+  height: 4rem;
+  background: #d1fae5;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 1rem;
+}
+
+.success-icon svg {
+  width: 2rem;
+  height: 2rem;
+  color: #059669;
+}
+
+.npub {
+  font-size: 0.75rem;
+  color: #6b7280;
+  word-break: break-all;
+  margin-top: 0.5rem;
+}
+
+.event-box {
+  background: #f9fafb;
+  padding: 1rem;
+  border-radius: 8px;
+  margin-top: 1rem;
+  text-align: left;
+}
+
+.event-box p {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #374151;
+}
+
+.event-box code {
+  font-size: 0.75rem;
+  color: #6b7280;
+  word-break: break-all;
+}
+
+/* Error */
+.error {
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  padding: 0.75rem;
+  border-radius: 8px;
+  margin-top: 1rem;
+  color: #dc2626;
+  font-size: 0.875rem;
+}
+
+.status {
+  text-align: center;
+  font-size: 0.75rem;
+  color: #9ca3af;
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid #f3f4f6;
+}
+
+.hidden {
+  display: none;
+}


### PR DESCRIPTION
Adds two standalone HTML/CSS/JS examples demonstrating OpenBunker authentication:

- **Button example**: Popup-based login with optional email pre-fill
- **Queue example**: 6-digit code verification with BunkerSigner event signing

Both examples work directly in the browser, use nostr-tools 2.19.3 from CDN, and include detailed READMEs.

Closes #15